### PR TITLE
Add const keyword to alias declarations.

### DIFF
--- a/src/MarkdownLiteral.jl
+++ b/src/MarkdownLiteral.jl
@@ -121,7 +121,7 @@ end
 
 # Some aliases, it's up to you which one to import.
 
-var"@markdownliteral" = var"@markdown"
-var"@mdx" = var"@markdown"
+const var"@markdownliteral" = var"@markdown"
+const var"@mdx" = var"@markdown"
 
 end


### PR DESCRIPTION
This prevents the identifiers var"@markdownliteral" and var"@mdx" from being assigned other values.