### PR TITLE
Added @mdx_str version to address issue #5.

### DIFF
--- a/src/MarkdownLiteral.jl
+++ b/src/MarkdownLiteral.jl
@@ -99,6 +99,22 @@ Result:
 ![](https://user-images.githubusercontent.com/6933510/146623300-316e5a17-2daf-43ed-b70c-6c33278faf32.png)
 """
 macro markdown(expr)
+    cm_parser = _make_cm_parser()
+        quote
+        result = $(esc(Expr(:macrocall, getfield(HypertextLiteral, Symbol("@htl")), __source__, expr)))
+        CMParsedRenderer(contents = result, parser = $cm_parser)
+    end
+end
+
+macro mdx_str(expr::String)
+    cm_parser = _make_cm_parser()
+    quote
+        result = $(esc(Expr(:macrocall, getfield(HypertextLiteral, Symbol("@htl_str")), __source__, expr)))
+        CMParsedRenderer(contents = result, parser = $cm_parser)
+    end
+end
+
+function _make_cm_parser()
     cm_parser = CommonMark.Parser()
     CommonMark.enable!(cm_parser, [
         CommonMark.AdmonitionRule(),
@@ -111,10 +127,7 @@ macro markdown(expr)
         CommonMark.TableRule(),
         CommonMark.TypographyRule(),
     ])
-    quote
-        result = $(esc(Expr(:macrocall, getfield(HypertextLiteral, Symbol("@htl")), __source__, expr)))
-        CMParsedRenderer(contents = result, parser = $cm_parser)
-    end
+    return cm_parser
 end
 
 Base.@kwdef struct CMParsedRenderer


### PR DESCRIPTION
Created `@mdx_str` from `@markdown` by using `@htl_str` in place of `@htl`.  This means that one need not escape \\ in `mdx" ``\LaTeX``"`, for example.  Factored out `_make_cm_parser()` 
**Considerations:** 
1. This will work best after pull [HypertextLiteral#30](https://github.com/JuliaPluto/HypertextLiteral.jl/pull/30), which aims to remove the  `@htl_str` behavior of interpolating (escaped) \\$, so it matches `@htl` and `cm" "` behavior.
2. I factored out the `_make_cm_parser` so `mdx" "` and `@markdown` would have consistent options; you may be able to think of a reason that they should parse differently.

Attached is a Pluto notebook demonstrating some behaviors of `@mdx(" ")`, `mdx" "`, `cm" "`, and `htl" "`
[mdxTesting2.zip](https://github.com/JuliaPluto/MarkdownLiteral.jl/files/8965651/mdxTesting2.zip)
 